### PR TITLE
Return the same exit code

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,9 +12,12 @@ function tooler (cb) {
 
     var pkgPath = path.dirname(file)
     var script = path.resolve(pkgPath, data.tooler)
-    fork(script, process.argv.slice(2), {
+    var child = fork(script, process.argv.slice(2), {
       cwd: process.cwd(),
       stdio: 'inherit'
+    })
+    child.on('close', function (code) {
+      process.exit(code);
     })
     cb(null)
   })


### PR DESCRIPTION
If the script fails, we should fail with the same exit code.

Tested only by hand. But it does work!
